### PR TITLE
Fix ERP Export Client pagination

### DIFF
--- a/src/Billing/ErpExportsClient.php
+++ b/src/Billing/ErpExportsClient.php
@@ -359,11 +359,11 @@ class ErpExportsClient extends AbstractBillingClient
                 throw new PublicApiClientException(sprintf('Error: Pagination not found in response. Raw response was: "%s"', $rawResponse));
             }
 
-            if ($response['pagination']['perPage'] < count($response['data']['values'])) {
+            if ($response['pagination']['currentPage'] === $response['pagination']['totalPages']) {
                 $lastPage = true;
+            } else {
+                $currentPage++;
             }
-
-            $currentPage++;
 
             if (! isset($response['data']['values']) || ! isset($response['data']['headers'])) {
                 throw new PublicApiClientException(sprintf('Error: Data not found in response. Raw response was: "%s"', $rawResponse));


### PR DESCRIPTION
This pull request addresses a concern related to the ERP Exports sync request. Specifically, it rectifies an issue wherein the createErpExportSync process enters an infinite loop due to the fact that the perPage parameter in pagination data never becomes less than the corresponding values in the response.

I have tested this solution on my machine, and it appears to be functioning as expected. I appreciate your attention to this matter.