### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
     "php": ">=8.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6.0 || ^7.0",
-    "symfony/polyfill-php80": "^1.29"
+    "guzzlehttp/guzzle": "^6.0 || ^7.0"
   },
   "require-dev": {
     "illuminate/validation": "^5.5 || ^6.0 || ^7.0",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: >=8.0`, so the polyfill requirement doesn't seem necessary anymore?